### PR TITLE
Reorder language installers; bump Node to 5.7.0

### DIFF
--- a/dev-base/Dockerfile
+++ b/dev-base/Dockerfile
@@ -86,4 +86,5 @@ ENV _GVM_NO_UPDATE_PROFILE true
 RUN curl -L -O https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer && \
     bash ./gvm-installer $_GVM_VERSION $APP_SYS_ROOT && \
     echo . $_GVM_ROOT/scripts/gvm >> $_GVM_PROFILE && \
-    chmod +x $_GVM_PROFILE
+    chmod +x $_GVM_PROFILE && \
+    /bin/bash -l -c "gvm install go1.4.3 && gvm use go1.4.3 --default"

--- a/dev-standard/Dockerfile
+++ b/dev-standard/Dockerfile
@@ -1,5 +1,8 @@
 FROM dev-base
 
+ENV _GO_VERSION go1.6
+RUN /bin/bash -l -c "gvm install $_GO_VERSION && gvm use $_GO_VERSION --default"
+
 ENV _RUBY_VERSION 2.3.0
 RUN /bin/bash -l -c \
     "rbenv install $_RUBY_VERSION && rbenv global $_RUBY_VERSION && \
@@ -11,11 +14,6 @@ RUN /bin/bash -l -c \
     "pyenv install $_PYTHON_VERSION && pyenv install $_PYTHON3_VERSION && \
     pyenv global $_PYTHON_VERSION"
 
-ENV _NODE_VERSION 5.6.0
+ENV _NODE_VERSION 5.7.0
 RUN /bin/bash -l -c \
     "nvm install $_NODE_VERSION && nvm alias default $_NODE_VERSION"
-
-ENV _GO_VERSION go1.6
-RUN /bin/bash -l -c \
-    "gvm install go1.4.3 && gvm use go1.4.3 && \
-    gvm install $_GO_VERSION && gvm use $_GO_VERSION --default"


### PR DESCRIPTION
Since Go 1.4.3 is only needed to compile later Go versions, it's now in the dev-base image. Reordered the language installers in dev-standard to reflect the expected update frequency of each language. Go seems to change least frequently, followed by Ruby, then Python, then Node.

cc: @ccostino
