### PR TITLE
pages-data data container

### DIFF
--- a/dev-standard/Dockerfile
+++ b/dev-standard/Dockerfile
@@ -17,3 +17,5 @@ RUN /bin/bash -l -c \
 ENV _NODE_VERSION 5.7.0
 RUN /bin/bash -l -c \
     "nvm install $_NODE_VERSION && nvm alias default $_NODE_VERSION"
+
+RUN /bin/bash -l -c "pip install awscli"

--- a/go
+++ b/go
@@ -40,19 +40,17 @@ IMAGES = %w(
   hmacproxy
   authdelegate
   pages
-  pages-sites
   lunr-server
   team-api
 )
 
-DATA_CONTAINERS = %w(
-  pages-sites
-)
-
+DATA_CONTAINERS = {
+  'pages-data' => 'pages'
+}
 
 DAEMON_TO_DATA_CONTAINERS = {
-  'nginx-18f' => ['pages-sites:ro'],
-  'pages' => ['pages-sites'],
+  'nginx-18f' => ['pages-data:ro'],
+  'pages' => ['pages-data:rw'],
 }
 
 def_command :build_images, 'Build Docker images' do |args|
@@ -65,9 +63,11 @@ def_command :build_images, 'Build Docker images' do |args|
 end
 
 def_command :create_data_containers, 'Create Docker data containers' do |args|
-  (args.empty? ? DATA_CONTAINERS : args).each do |container_name|
-    exec_cmd "docker run --name #{container_name} #{container_name} " \
-      "echo Created data container \\\"#{container_name}\\\""
+  (args.empty? ? DATA_CONTAINERS.keys : args).each do |container_name|
+    base_image = DATA_CONTAINERS[container_name]
+    exec_cmd "docker run --name #{container_name} #{base_image} " \
+      "echo Created data container \\\"#{container_name}\\\" " \
+      "from \\\"#{base_image}\\\""
   end
 end
 

--- a/go
+++ b/go
@@ -123,4 +123,9 @@ def_command :rm_containers, 'Remove stopped containers' do
     'grep -v NAMES)'
 end
 
+def_command :rm_images, 'Remove unused images' do
+  exec_cmd 'docker images | grep \'^<none>\' | awk \'{ print $3 }\' | ' \
+    'xargs docker rmi'
+end
+
 execute_command ARGV

--- a/pages-sites/Dockerfile
+++ b/pages-sites/Dockerfile
@@ -1,0 +1,4 @@
+FROM dev-standard
+
+# TODO(mbland): Do an s3 sync of the 18f-pages bucket on startup.
+VOLUME $APP_SYS_ROOT/pages/sites

--- a/pages-sites/Dockerfile
+++ b/pages-sites/Dockerfile
@@ -1,4 +1,0 @@
-FROM dev-standard
-
-# TODO(mbland): Do an s3 sync of the 18f-pages bucket on startup.
-VOLUME $APP_SYS_ROOT/pages/sites

--- a/pages/Dockerfile
+++ b/pages/Dockerfile
@@ -13,4 +13,7 @@ USER pages
 WORKDIR $APP_SYS_ROOT/pages
 
 EXPOSE 5000
-CMD ["/bin/bash", "-l", "-c", "18f-pages pages-config.json"]
+CMD ["/bin/bash", "-l", "-c", \
+     "source env-secret.sh && \
+      aws s3 sync s3://18f-pages/sites $APP_SYS_ROOT/pages/sites && \
+      18f-pages pages-config.json"]

--- a/pages/Dockerfile
+++ b/pages/Dockerfile
@@ -6,9 +6,9 @@ RUN bash -l -c "npm install -g 18f-pages-server@$_PAGES_VERSION && \
     gem install jekyll -v $_JEKYLL_VERSION"
 
 RUN groupadd -r pages && useradd -r -m -g pages pages && \
-    mkdir -p $APP_SYS_ROOT/pages/repos && \
-    chown pages:pages $APP_SYS_ROOT/pages/repos
-VOLUME $APP_SYS_ROOT/pages/repos
+    mkdir -p $APP_SYS_ROOT/pages/repos $APP_SYS_ROOT/pages/sites && \
+    chown pages:pages $APP_SYS_ROOT/pages/repos $APP_SYS_ROOT/pages/sites
+VOLUME $APP_SYS_ROOT/pages/repos $APP_SYS_ROOT/pages/sites
 USER pages
 WORKDIR $APP_SYS_ROOT/pages
 

--- a/pages/Dockerfile
+++ b/pages/Dockerfile
@@ -6,12 +6,11 @@ RUN bash -l -c "npm install -g 18f-pages-server@$_PAGES_VERSION && \
     gem install jekyll -v $_JEKYLL_VERSION"
 
 RUN groupadd -r pages && useradd -r -m -g pages pages && \
-    mkdir -p $APP_SYS_ROOT/pages/repos $APP_SYS_ROOT/pages/sites && \
-    chown pages:pages $APP_SYS_ROOT/pages/repos $APP_SYS_ROOT/pages/sites
-VOLUME $APP_SYS_ROOT/pages/repos $APP_SYS_ROOT/pages/sites
+    mkdir -p $APP_SYS_ROOT/pages/repos && \
+    chown pages:pages $APP_SYS_ROOT/pages/repos
+VOLUME $APP_SYS_ROOT/pages/repos
 USER pages
 WORKDIR $APP_SYS_ROOT/pages
 
 EXPOSE 5000
-# TODO(mbland): Do an s3 sync of the 18f-pages bucket on startup.
 CMD ["/bin/bash", "-l", "-c", "18f-pages pages-config.json"]


### PR DESCRIPTION
Depends on #4. Adds `pages-sites/Dockerfile` to produce a data container for 18F Pages sites.

This enables the `pages` container to write to `/usr/local/18f/pages/sites`, and the `nginx-18f` container to only read from it.

You can try this locally via:

``` sh
$ ./go run_data_containers

# In one shell:
$ ./go run_pages

# In another shell:
$ ./go run_nginx
```

In the Pages shell, you can freely write to files in `/usr/local/18f/pages/sites`, and you can read them in the Nginx shell, but not modify anything.

cc: @jcscottiii @ccostino @afeld 
