### PR TITLE
Implement local Docker network

### DIFF
--- a/authdelegate/config/authdelegate-config.json
+++ b/authdelegate/config/authdelegate-config.json
@@ -1,10 +1,10 @@
 {
   "port": 9000,
   "upstreams": [
-    { "url": "http://127.0.0.1:8083/",
+    { "url": "http://hmacproxy:8083/",
       "header_name": "Team-Api-Signature"
     },
-    { "url": "http://127.0.0.1:4180/oauth2/auth"
+    { "url": "http://oauth2_proxy:4180/oauth2/auth"
     }
   ]
 }

--- a/hmacproxy/Dockerfile
+++ b/hmacproxy/Dockerfile
@@ -7,7 +7,7 @@ RUN groupadd -r hmacproxy && useradd -r -m -g hmacproxy hmacproxy
 USER hmacproxy
 WORKDIR $APP_SYS_ROOT/hmacproxy
 
-EXPOSE 8083
+EXPOSE 8083 8084
 COPY ["entrypoint.sh", "entrypoint.sh"]
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["run-server"]

--- a/hmacproxy/entrypoint.sh
+++ b/hmacproxy/entrypoint.sh
@@ -3,8 +3,25 @@
 source /etc/profile.d/gvm.sh
 source config/env-secret.sh
 
+HMACPROXY_SERVER_PORT=8083
+HMACPROXY_PROXY_PORT=8084
+HMACPROXY_SIGN_HEADER="Team-Api-Signature"
+HMACPROXY_HEADERS="Content-Type,Date"
+
 if [ "$1" = "run-server" ]; then
-  exec hmacproxy -auth -port 8083 -secret $HMACAUTH_SECRET \
-    -sign-header Team-Api-Signature -headers Content-Type,Date
+  exec hmacproxy -auth -port $HMACPROXY_SERVER_PORT -secret $HMACAUTH_SECRET \
+    -sign-header $HMACPROXY_SIGN_HEADER -headers $HMACPROXY_HEADERS
+fi
+if [ "$1" = "run-proxy" ]; then
+  UPSTREAM="$2"
+
+  if [ -z "$UPSTREAM" ]; then
+    echo "No upstream server specified"
+    exit 1
+  fi
+
+  exec hmacproxy -port $HMACPROXY_PROXY_PORT -secret $HMACAUTH_SECRET \
+    -sign-header $HMACPROXY_SIGN_HEADER -headers $HMACPROXY_HEADERS \
+    -upstream $UPSTREAM
 fi
 exec "$@"

--- a/lunr-server/config/lunr-server-config.json
+++ b/lunr-server/config/lunr-server-config.json
@@ -1,9 +1,5 @@
 {
   "corpora": [
-    { "name": "The Hub",
-      "baseurl": "https://hub.18f.gov",
-      "indexPath": "/usr/local/18f/hub/repo/_site/search-index.json"
-    },
     { "name": "Guides Template",
       "baseurl": "https://pages.18f.gov",
       "indexPath": "/usr/local/18f/pages/sites/pages.18f.gov/guides-template/search-index.json"

--- a/nginx/config/auth/locations.conf
+++ b/nginx/config/auth/locations.conf
@@ -1,5 +1,5 @@
 location = /oauth2/start {
-  proxy_pass http://127.0.0.1:4180/oauth2/start?rd=%2F$server_name$arg_rd;
+  proxy_pass http://oauth2_proxy:4180/oauth2/start?rd=%2F$server_name$arg_rd;
   proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Scheme $scheme;
@@ -9,7 +9,7 @@ location = /oauth2/start {
 }
 
 location / {
-  proxy_pass http://127.0.0.1:4180/;
+  proxy_pass http://oauth2_proxy:4180/;
   proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Scheme $scheme;

--- a/nginx/config/vhosts/auth.conf
+++ b/nginx/config/vhosts/auth.conf
@@ -11,7 +11,7 @@ server {
   location = /oauth2/callback {
     proxy_intercept_errors on;
     error_page 403 /403/index.html?rd=$arg_state;
-    proxy_pass http://127.0.0.1:4180;
+    proxy_pass http://oauth2_proxy:4180;
     proxy_connect_timeout 1;
     proxy_send_timeout 30;
     proxy_read_timeout 30;
@@ -24,7 +24,7 @@ server {
   }
 
   location = /oauth2/start {
-    proxy_pass http://127.0.0.1:4180;
+    proxy_pass http://oauth2_proxy:4180;
     proxy_connect_timeout 1;
     proxy_send_timeout 30;
     proxy_read_timeout 30;

--- a/nginx/config/vhosts/hub.conf
+++ b/nginx/config/vhosts/hub.conf
@@ -68,7 +68,7 @@ server {
 }
 
 server {
-  listen 127.0.0.1:8080;
+  listen 8080;
   server_name hub.18f.gov;
   port_in_redirect off;
   error_page 404 /404/index.html;
@@ -87,7 +87,7 @@ server {
   }
 
   location /search {
-    proxy_pass http://127.0.0.1:7777/;
+    proxy_pass http://lunr-server:7777/;
   }
 
   location "~^/auth/(?<authenticated_user>[^/]+)/index.html$" {

--- a/nginx/config/vhosts/pages.conf
+++ b/nginx/config/vhosts/pages.conf
@@ -11,7 +11,7 @@ server {
 }
 
 server {
-  listen 127.0.0.1:8081;
+  listen 8081;
   server_name playbook.cio.gov;
   port_in_redirect off;
 
@@ -42,7 +42,7 @@ server {
   }
 
   location /designstandards {
-    proxy_pass http://127.0.0.1:8081/designstandards;
+    proxy_pass http://localhost:8081/designstandards;
     proxy_http_version 1.1;
     proxy_redirect off;
     proxy_set_header Host playbook.cio.gov;
@@ -184,7 +184,7 @@ server {
 }
 
 server {
-  listen 127.0.0.1:8080;
+  listen 8080;
   server_name pages-staging.18f.gov pages-releases.18f.gov pages-internal.18f.gov;
   port_in_redirect off;
 
@@ -197,7 +197,7 @@ server {
 
 # handbook server
 server {
-  listen 127.0.0.1:8080;
+  listen 8080;
   server_name  handbook.18f.gov;
   port_in_redirect off;
 

--- a/nginx/config/vhosts/team-api.conf
+++ b/nginx/config/vhosts/team-api.conf
@@ -20,12 +20,12 @@ server {
 
   location = /auth {
     internal;
-    proxy_pass http://127.0.0.1:9000;
+    proxy_pass http://authdelegate:9000;
     proxy_set_header X-Original-URI $request_uri;
   }
 
   location /deploy {
-    proxy_pass http://localhost:6000/;
+    proxy_pass http://team-api:6000/;
     proxy_http_version 1.1;
     proxy_redirect off;
 
@@ -41,7 +41,7 @@ server {
   }
 
   location /pshb {
-    proxy_pass http://localhost:6001/;
+    proxy_pass http://team-api:6001/;
     proxy_http_version 1.1;
     proxy_redirect off;
 

--- a/nginx/config/vhosts/tock.conf
+++ b/nginx/config/vhosts/tock.conf
@@ -20,7 +20,7 @@ server {
 }
 
 server {
-  listen 127.0.0.1:8080;
+  listen 8080;
   server_name tock.18f.gov;
   port_in_redirect off;
 
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-  listen 127.0.0.1:8080;
+  listen 8080;
   server_name tock-staging.18f.gov;
   port_in_redirect off;
 

--- a/oauth2_proxy/config/oauth2_proxy.cfg
+++ b/oauth2_proxy/config/oauth2_proxy.cfg
@@ -2,14 +2,14 @@
 ## https://github.com/bitly/oauth2_proxy
 
 ## <addr>:<port> to listen on for HTTP clients
-http_address = "127.0.0.1:4180"
+http_address = "oauth2_proxy:4180"
 
 ## the OAuth Redirect URL.
 redirect_url = "https://auth.18f.gov/oauth2/callback"
 
 ## the http url(s) of the upstream endpoint. If multiple, routing is based on path
 upstreams = [
-    "http://127.0.0.1:8080/"
+    "http://nginx:8080/"
 ]
 
 ## pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream


### PR DESCRIPTION
Depends on #7. With this PR, it's possible to bring up the whole system up and down with:

``` sh
$ ./go start
$ ./go stop
```

To run and test locally, update `/etc/hosts` with the following (substituting the IP addresses with that returned from `docker-machine ip`) before visiting the hosts in your browser:

```
# Testing locally with 18F/knowledge-sharing-toolkit
# Run `docker-machine env` to get the current IP.
192.168.99.100 pages.18f.gov
192.168.99.100 pages-staging.18f.gov
192.168.99.100 pages-internal.18f.gov
192.168.99.100 pages-releases.18f.gov
192.168.99.100 team-api.18f.gov
192.168.99.100 hub.18f.gov
192.168.99.100 handbook.18f.gov
```

With this setup all the required secrets in place (which I'll document very soon), you'll have a complete system equivalent to currently running on those hosts.

Well, almost. There's couple rough spots to smooth off. But mostly.

A really nice unexpected feature: The Docker network 18f/knowledge-sharing-toolkit created by `./go create_network` command [binds the container names to Docker network addresses via a local DNS mechanism](https://docs.docker.com/engine/userguide/networking/dockernetworks/#docker-embedded-dns-server). This means that all of the configurations needed to be updated to reference specific container "hosts", rather than "localhost" or "127.0.0.1". Consequently, the dependencies between services become more explicit via the configuration files.

There's another goodie documented in the commit message for f235b54db4154949051057de73509c218b9724bd, but you can just read that for yourself. (Too long to paste here.)

Really close to having it all done now, modulo a couple small fixes/features for 18F/lunr-server and 18F/pages-server (notably doing a `s3 sync` after successful builds). Plus, I still have to add the Hub, which won't be too hard at this point, I don't think.

cc: @jcscottiii @ccostino @afeld @catherinedevlin @batemapf @ertzeid @mtorres253 
